### PR TITLE
Adding type checking of bodyless predicates

### DIFF
--- a/prolog/mavis.pl
+++ b/prolog/mavis.pl
@@ -2,6 +2,7 @@
                  , has_intersection/2
                  , has_subtype/2
                  , known_type/1
+                 , build_type_assertions/3
                  ]).
 
 

--- a/prolog/mavis.pl
+++ b/prolog/mavis.pl
@@ -103,8 +103,19 @@ build_type_assertions(Slash, Head, TypeGoal) :-
     exclude(=@=(the(any, _)), AllTypes, Types),
     xfy_list(',', TypeGoal, Types).
 
+bodyless_predicate(Term) :-
+    \+ Term = (:-_),
+    \+ Term = (_:-_),
+    \+ Term = (_-->_),
+    \+ Term = end_of_file.
+
 user:term_expansion((Head:-Body), (Head:-TypeGoal,Body)) :-
     Slash = '/',
+    build_type_assertions(Slash, Head, TypeGoal).
+
+user:term_expansion(Head,(Head:-TypeGoal)) :-
+    bodyless_predicate(Head),
+    Slash = '/', 
     build_type_assertions(Slash, Head, TypeGoal).
 
 user:term_expansion((Head-->Body), (Head-->{TypeGoal},Body)) :-


### PR DESCRIPTION
Predicates of the form 
```
/** 
 * first_string(+X:list(string), ?Y:string) is det.
 */
first_string([X|_],X).
```

Were not being recognised by term expansion as they have an empty body and the pattern matching was on `:-`

This fix checks to see if the `Term` is none of the other known Term types which can exist at top_level, and if it is not it creates a `:-` and adds the type checking to the body.